### PR TITLE
Fixing Python4 compatibility issue

### DIFF
--- a/gpcharts.py
+++ b/gpcharts.py
@@ -8,7 +8,7 @@
 # Python3 compatibility
 import sys
 python_version = sys.version_info[0]
-if python_version == 3:
+if python_version >= 3:
     try:
         from past.builtins import xrange
     except ImportError:


### PR DESCRIPTION
It is presumed that Python4 will be mostly, if not completely, backwards
compatible with Python3. At the same time, it will not revert to Python2
compatibility. As such, Python3 patches like this should also be written to be
seen by future versions of Python, so they're less likely to break with that eventual update.
